### PR TITLE
Connor/eng 1914 ensure select works with all ways of querying sqlalchemy

### DIFF
--- a/src/sqlalchemy_oso_cloud/select_impl.py
+++ b/src/sqlalchemy_oso_cloud/select_impl.py
@@ -1,11 +1,18 @@
 import sqlalchemy.sql
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 from oso_cloud import Value
-from typing import  TypeVar
+from typing import  TypeVar, Generic, Any, overload, Type, Tuple, Union
 from .auth import _apply_authorization_options
 
 Self = TypeVar("Self", bound="Select")
+_T = TypeVar("_T", bound=Tuple[Any, ...])
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
 
-class Select(sqlalchemy.sql.Select):
+class Select(sqlalchemy.sql.Select[_T], Generic[_T]):
     """A Select subclass that adds authorization functionality"""
 
     inherit_cache = True
@@ -18,9 +25,34 @@ class Select(sqlalchemy.sql.Select):
     def authorized(self: Self, actor: Value, action: str) -> Self:
         """Add authorization filtering to the select statement"""
         return _apply_authorization_options(self, actor, action)
-    
-    
-def select(*args, **kwargs) -> Select:
+
+# Single entity overload
+@overload
+def select(entity: Type[T]) -> Select[Tuple[T]]: ...
+
+# Single column overload
+@overload
+def select(column: InstrumentedAttribute[T]) -> Select[Tuple[T]]: ...
+
+@overload
+def select(
+    arg1: Union[Type[T1], InstrumentedAttribute[T1]], 
+    arg2: Union[Type[T2], InstrumentedAttribute[T2]]) -> Select[Tuple[T1, T2]]: ...
+
+@overload
+def select(arg1: Union[Type[T1], InstrumentedAttribute[T1]], 
+           arg2: Union[Type[T2], InstrumentedAttribute[T2]], 
+           arg3: Union[Type[T3], InstrumentedAttribute[T3]]) -> Select[Tuple[T1, T2, T3]]: ...
+
+@overload
+def select(arg1: Union[Type[T1], InstrumentedAttribute[T1]], 
+           arg2: Union[Type[T2], InstrumentedAttribute[T2]], 
+           arg3: Union[Type[T3], InstrumentedAttribute[T3]], 
+           arg4: Union[Type[T4], InstrumentedAttribute[T4]]) -> Select[Tuple[T1, T2, T3, T4]]: ...
+
+@overload
+def select(*entities: Any) -> Select[Any]: ...    
+def select(*entities, **kwargs) -> Select[Any]:
     """
     Create an sqlalchemy_oso_cloud.Select() object
 
@@ -33,4 +65,4 @@ def select(*args, **kwargs) -> Select:
         stmt = select(Document).where(Document.private == True).authorized(actor, "read")
         documents = session.execute(stmt)
     """
-    return Select(*args, **kwargs)
+    return Select(*entities, **kwargs)

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -146,6 +146,19 @@ class Session(sqlalchemy.orm.Session):
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
   ) -> Result[Tuple[T1, T2, T3, T4]]: ...
+  
+  # Fallback overload
+  @overload
+  def execute( 
+      self,
+      statement: Any,
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Any]: ...
 
   def execute( 
       self,

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -1,8 +1,9 @@
 import sqlalchemy.orm
 from .query import Query
-from sqlalchemy.engine import Row
+from sqlalchemy.engine import Row, Result
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from typing import Type, TypeVar, overload, Any, Tuple, Union
+from sqlalchemy.sql.selectable import TypedReturnsRows
+from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
@@ -79,3 +80,98 @@ class Session(sqlalchemy.orm.Session):
       All other queries types return Query[Any].
       """
       return super().query(*entities, **kwargs)
+
+  # Execute overloads for our custom Select class
+  # Single entity
+  @overload # type: ignore[override]
+  def execute(
+      self,
+      statement: TypedReturnsRows[Tuple[T]],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Tuple[T]]: ...
+
+  # Two entities
+  @overload
+  def execute(
+      self,
+      statement: TypedReturnsRows[Tuple[T1, T2]],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Tuple[T1, T2]]: ...
+
+  # Three entities
+  @overload
+  def execute(
+      self,
+      statement: TypedReturnsRows[Tuple[T1, T2, T3]],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Tuple[T1, T2, T3]]: ...
+
+  # Four entities
+  @overload
+  def execute(
+      self,
+      statement: TypedReturnsRows[Tuple[T1, T2, T3, T4]],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Tuple[T1, T2, T3, T4]]: ...
+
+  # Fallback for 5+ entities or any other Select
+  @overload
+  def execute(
+      self,
+      statement: TypedReturnsRows[Any],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None, 
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Any]: ...
+
+  def execute( 
+      self,
+      statement: TypedReturnsRows[Any],
+      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
+      *,
+      execution_options: Optional[Mapping[str, Any]] = None,
+      bind_arguments: Optional[dict[str, Any]] = None,
+      _parent_execute_state: Optional[Any] = None,
+      _add_event: Optional[Any] = None,
+  ) -> Result[Any]:
+      """
+      Execute a SQL expression construct.
+
+      This method supports all the same arguments as
+      [`sqlalchemy.orm.Session.execute`](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.execute)
+      and returns appropriate Result types based on the statement being executed.
+
+      When used with our custom Select class or Query class that have been filtered
+      with .authorized(), the authorization filtering will be applied.
+      """
+      return super().execute(  # type: ignore[misc]
+          statement,
+          params,
+          execution_options=execution_options, # type: ignore[arg-type]
+          bind_arguments=bind_arguments,
+          _parent_execute_state=_parent_execute_state,
+          _add_event=_add_event,
+      )

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -2,10 +2,22 @@ import sqlalchemy.orm
 from .query import Query
 from sqlalchemy.engine import Row, Result
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from sqlalchemy.orm._typing import OrmExecuteOptionsParameter
-from sqlalchemy.util._collections import EMPTY_DICT
+
 from sqlalchemy.sql.selectable import TypedReturnsRows
 from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping, TypeAlias
+
+try:
+    from sqlalchemy.orm._typing import OrmExecuteOptionsParameter as _OrmExecuteOptionsParameter
+    from sqlalchemy.util._collections import EMPTY_DICT as _EMPTY_DICT
+
+    OrmExecuteOptionsParameter: TypeAlias = _OrmExecuteOptionsParameter
+    EMPTY_DICT = _EMPTY_DICT
+
+except ImportError:
+    # Fallback for internal types
+    OrmExecuteOptionsParameter: TypeAlias = Mapping[str, Any] # type: ignore[misc, no-redef]
+    EMPTY_DICT = {} # type: ignore[assignment]
+   
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
@@ -91,7 +103,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -104,7 +116,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -117,7 +129,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2, T3]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -130,7 +142,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2, T3, T4]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -141,7 +153,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Any],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
+      execution_options: "OrmExecuteOptionsParameter" = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -94,7 +94,6 @@ class Session(sqlalchemy.orm.Session):
       """
       return super().query(*entities, **kwargs)
 
-  # Execute overloads for our custom Select class
   # Single entity
   @overload # type: ignore[override]
   def execute(

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -2,8 +2,10 @@ import sqlalchemy.orm
 from .query import Query
 from sqlalchemy.engine import Row, Result
 from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.orm._typing import OrmExecuteOptionsParameter
+from sqlalchemy.util._collections import EMPTY_DICT
 from sqlalchemy.sql.selectable import TypedReturnsRows
-from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping
+from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping, TypeAlias
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
@@ -89,7 +91,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: Optional[Mapping[str, Any]] = None,
+      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -102,7 +104,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: Optional[Mapping[str, Any]] = None,
+      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -115,7 +117,7 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2, T3]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: Optional[Mapping[str, Any]] = None,
+      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -128,31 +130,18 @@ class Session(sqlalchemy.orm.Session):
       statement: TypedReturnsRows[Tuple[T1, T2, T3, T4]],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: Optional[Mapping[str, Any]] = None,
+      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
   ) -> Result[Tuple[T1, T2, T3, T4]]: ...
-
-  # Fallback for 5+ entities or any other Select
-  @overload
-  def execute(
-      self,
-      statement: TypedReturnsRows[Any],
-      params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
-      *,
-      execution_options: Optional[Mapping[str, Any]] = None, 
-      bind_arguments: Optional[dict[str, Any]] = None,
-      _parent_execute_state: Optional[Any] = None,
-      _add_event: Optional[Any] = None,
-  ) -> Result[Any]: ...
 
   def execute( 
       self,
       statement: TypedReturnsRows[Any],
       params: Optional[Union[Mapping[str, Any], Sequence[Mapping[str, Any]]]] = None,
       *,
-      execution_options: Optional[Mapping[str, Any]] = None,
+      execution_options: OrmExecuteOptionsParameter = EMPTY_DICT,
       bind_arguments: Optional[dict[str, Any]] = None,
       _parent_execute_state: Optional[Any] = None,
       _add_event: Optional[Any] = None,
@@ -167,10 +156,10 @@ class Session(sqlalchemy.orm.Session):
       When used with our custom Select class or Query class that have been filtered
       with .authorized(), the authorization filtering will be applied.
       """
-      return super().execute(  # type: ignore[misc]
+      return super().execute( 
           statement,
           params,
-          execution_options=execution_options, # type: ignore[arg-type]
+          execution_options=execution_options, 
           bind_arguments=bind_arguments,
           _parent_execute_state=_parent_execute_state,
           _add_event=_add_event,

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -4,19 +4,18 @@ from sqlalchemy.engine import Row, Result
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from sqlalchemy.sql.selectable import TypedReturnsRows
-from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping, TypeAlias
+from typing import Type, TypeVar, overload, Any, Tuple, Union, Optional, Sequence, Mapping, TYPE_CHECKING
 
-try:
-    from sqlalchemy.orm._typing import OrmExecuteOptionsParameter as _OrmExecuteOptionsParameter
-    from sqlalchemy.util._collections import EMPTY_DICT as _EMPTY_DICT
-
-    OrmExecuteOptionsParameter: TypeAlias = _OrmExecuteOptionsParameter
-    EMPTY_DICT = _EMPTY_DICT
-
-except ImportError:
-    # Fallback for internal types
-    OrmExecuteOptionsParameter: TypeAlias = Mapping[str, Any] # type: ignore[misc, no-redef]
-    EMPTY_DICT = {} # type: ignore[assignment]
+if TYPE_CHECKING:
+    from sqlalchemy.orm._typing import OrmExecuteOptionsParameter
+    from sqlalchemy.util._collections import EMPTY_DICT
+else:
+    try:
+        from sqlalchemy.orm._typing import OrmExecuteOptionsParameter
+        from sqlalchemy.util._collections import EMPTY_DICT
+    except ImportError:
+        OrmExecuteOptionsParameter = Mapping[str, Any]  # type: ignore[misc]
+        EMPTY_DICT = {}  # type: ignore[assignment]
    
 
 T = TypeVar("T")


### PR DESCRIPTION
Essentially this adds the same sort of overrides to `select()` and `execute()` as those we have in `Query`