### PR TITLE
ENG-1956: provide better devx when using our wrapper functions

### DIFF
--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -2,11 +2,10 @@
 Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#orm-declarative-mapping)
 [authorization data](https://www.osohq.com/docs/authorization-data) in your ORM models.
 """
-import inspect
 
 from typing import Callable, Optional, Protocol, Any
 from typing_extensions import ParamSpec, TypeVar, Concatenate
-from functools import partial, wraps
+from functools import wraps
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship
 from typing import Union

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -22,12 +22,7 @@ P = ParamSpec('P')
 T = TypeVar('T')
 
 def wrap(func: Callable[P, Any]) -> Callable[[Callable[P, T]], Callable[P, T]]:
-    """Wrap a SQLAlchemy function in a type-safe way.
-    
-    Args:
-        func: The original SQLAlchemy function to wrap
-        custom_params: Optional dict of custom parameters to add to the signature
-    """
+    """Wrap a SQLAlchemy function in a type-safe way."""
     def decorator(wrapper: Callable[P, T]) -> Callable[P, T]:
         @wraps(func)
         def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -2,7 +2,6 @@
 Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#orm-declarative-mapping)
 [authorization data](https://www.osohq.com/docs/authorization-data) in your ORM models.
 """
-import inspect
 from typing import Callable, Any, TypeVar, ParamSpec
 from functools import wraps
 

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -5,7 +5,6 @@ Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapp
 
 from typing import Callable, Optional, Protocol, Any
 from typing_extensions import ParamSpec, TypeVar, Concatenate
-from functools import wraps
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship
 

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -26,7 +26,6 @@ R = TypeVar('R', covariant=True)
 def _wrap(func: Callable[P, Any]) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Wrap a SQLAlchemy function in a type-safe way."""
     def decorator(wrapper: Callable[P, T]) -> Callable[P, T]:
-      @wraps(func)
       def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
           return wrapper(*args, **kwargs)
       return wrapped
@@ -39,7 +38,6 @@ class _WithExtraKwargs(Protocol[P, R]):
 def _add_params(wrapped_func: Callable[P, R]) -> Callable[[_WithExtraKwargs[P, R]], _WithExtraKwargs[P, R]]:
   """Adds extra keyword parameters to `remote_relation` in order to support static type checking."""
   def decorator(wrapper: Callable[Concatenate[str, Optional[str], P], R]) -> _WithExtraKwargs[P, R]:
-    @wraps(wrapped_func)
     def wrapped(remote_resource_name: str, remote_relation_key: Optional[str] = None, *args: P.args, **kwargs: P.kwargs) -> R:
       return wrapper(remote_resource_name, remote_relation_key, *args, **kwargs)
     return wrapped

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -4,9 +4,9 @@ Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapp
 """
 import inspect
 
-from typing import Callable, Any, Optional, Dict
-from typing_extensions import ParamSpec, TypeVar
-from functools import wraps
+from typing import Callable, Optional, Protocol, Any
+from typing_extensions import ParamSpec, TypeVar, Concatenate
+from functools import partial, wraps
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship
 from typing import Union
@@ -23,67 +23,31 @@ _REMOTE_RELATION_INFO_KEY = "_oso.remote_relation"
 
 P = ParamSpec('P')
 T = TypeVar('T')
+R = TypeVar('R', covariant=True)
 
-def wrap(func: Callable[P, Any]) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def _wrap(func: Callable[P, Any]) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Wrap a SQLAlchemy function in a type-safe way."""
     def decorator(wrapper: Callable[P, T]) -> Callable[P, T]:
-        @wraps(func)
-        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-            return wrapper(*args, **kwargs)
-        return wrapped
+      @wraps(func)
+      def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+          return wrapper(*args, **kwargs)
+      return wrapped
     return decorator
 
-F = TypeVar('F', bound=Callable[..., Any])
+class _WithExtraKwargs(Protocol[P, R]):
+    def __call__(self, remote_resource_name: str, remote_relation_key: Optional[str] = None, *args: P.args, **kwargs: P.kwargs) -> R:
+        ...
 
-def wrap_with_signature(
-    wrapped_func: Callable,
-    extra_params: Optional[Dict[str, Dict[str, Any]]] = None
-):
-    """
-    Decorator that copies signature from wrapped_func and optionally adds extra parameters.
-    
-    Args:
-        wrapped_func: The function whose signature to copy
-        extra_params: Dict of {param_name: {'annotation': type, 'default': value}}
-    """
-    def decorator(wrapper_func: F) -> F:
-        # Get the original signature
-        sig = inspect.signature(wrapped_func)
-        params = list(sig.parameters.values())
-        
-        # Add extra parameters as keyword-only
-        if extra_params:
-            for name, info in extra_params.items():
-                param = inspect.Parameter(
-                    name,
-                    inspect.Parameter.KEYWORD_ONLY,
-                    default=info.get('default', inspect.Parameter.empty),
-                    annotation=info.get('annotation', inspect.Parameter.empty)
-                )
-                params.append(param)
-        
-        # Create new signature
-        new_sig = sig.replace(parameters=params)
-        
-        # Apply to wrapper function
-        wrapper_func.__signature__ = new_sig
-        wrapper_func.__annotations__ = getattr(wrapped_func, '__annotations__', {})
-        
-        # Add extra param annotations
-        if extra_params:
-            for name, info in extra_params.items():
-                if 'annotation' in info:
-                    wrapper_func.__annotations__[name] = info['annotation']
-        
-        wrapper_func.__name__ = wrapped_func.__name__
-        wrapper_func.__doc__ = wrapped_func.__doc__
-        wrapper_func.__module__ = wrapped_func.__module__
-        
-        return wrapper_func
-    
-    return decorator
+def _add_params(wrapped_func: Callable[P, R]) -> Callable[[_WithExtraKwargs[P, R]], _WithExtraKwargs[P, R]]:
+  """Adds extra keyword parameters to `remote_relation` in order to support static type checking."""
+  def decorator(wrapper: Callable[Concatenate[str, Optional[str], P], R]) -> _WithExtraKwargs[P, R]:
+    @wraps(wrapped_func)
+    def wrapped(remote_resource_name: str, remote_relation_key: Union[str, None] = None, *args: P.args, **kwargs: P.kwargs) -> R:
+      return wrapper(remote_resource_name, remote_relation_key, *args, **kwargs)
+    return wrapped
+  return decorator
 
-@wrap_with_signature(relationship)
+@_wrap(relationship)
 def relation(*args, **kwargs) -> Relationship:
   """
   A wrapper around [`sqlalchemy.orm.relationship`](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship)
@@ -98,7 +62,7 @@ def relation(*args, **kwargs) -> Relationship:
   rel.info[_RELATION_INFO_KEY] = None
   return rel
 
-@wrap(mapped_column)
+@_wrap(mapped_column)
 def attribute(*args, **kwargs) -> MappedColumn:
   """
   A wrapper around [`sqlalchemy.orm.mapped_column`](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.mapped_column)
@@ -112,7 +76,8 @@ def attribute(*args, **kwargs) -> MappedColumn:
   col.column.info[_ATTRIBUTE_INFO_KEY] = None
   return col
 
-def remote_relation(remote_resource_name: str, remote_relation_key: Union[str, None] = None, *args, **kwargs) -> MappedColumn:
+@_add_params(mapped_column)
+def remote_relation(remote_resource_name: str, remote_relation_key: Optional[str] = None, *args, **kwargs) -> MappedColumn:
   """
   A wrapper around [`sqlalchemy.orm.mapped_column`](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.mapped_column)
   that indicates that the attribute corresponds to `has_relation` facts (to a resource not defined in the local database) in Oso with the following two arguments:

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -8,7 +8,6 @@ from typing_extensions import ParamSpec, TypeVar, Concatenate
 from functools import wraps
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship
-from typing import Union
 
 class Resource:
   """
@@ -41,7 +40,7 @@ def _add_params(wrapped_func: Callable[P, R]) -> Callable[[_WithExtraKwargs[P, R
   """Adds extra keyword parameters to `remote_relation` in order to support static type checking."""
   def decorator(wrapper: Callable[Concatenate[str, Optional[str], P], R]) -> _WithExtraKwargs[P, R]:
     @wraps(wrapped_func)
-    def wrapped(remote_resource_name: str, remote_relation_key: Union[str, None] = None, *args: P.args, **kwargs: P.kwargs) -> R:
+    def wrapped(remote_resource_name: str, remote_relation_key: Optional[str] = None, *args: P.args, **kwargs: P.kwargs) -> R:
       return wrapper(remote_resource_name, remote_relation_key, *args, **kwargs)
     return wrapped
   return decorator

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -2,7 +2,8 @@
 Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#orm-declarative-mapping)
 [authorization data](https://www.osohq.com/docs/authorization-data) in your ORM models.
 """
-from typing import Callable, Any, TypeVar, ParamSpec
+from typing import Callable, Any
+from typing_extensions import ParamSpec, TypeVar
 from functools import wraps
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship


### PR DESCRIPTION
aka method parameter autocomplete and type checking.

This change literally forwards the method signature of our wrapped sqlalchemy function to our orm wrapper - which has pros and cons.

pros:
* parameter autocomplete and type checking work!
* users can see docs for the actual function that's doing 99% of the work - better user experience?

cons:
* our docs aren't shown on hover/type (users can still cmd+click to navigate to our wrappers, but only after they've typed out our function)

<img width="658" alt="Screenshot 2025-07-02 at 4 36 39 PM" src="https://github.com/user-attachments/assets/cd14d504-83ca-4859-b0e0-bcb62ae9e1bc" />
<img width="680" alt="Screenshot 2025-07-02 at 4 36 52 PM" src="https://github.com/user-attachments/assets/799e00e0-a0f3-48ab-a491-0b7c97c49fc2" />
<img width="444" alt="Screenshot 2025-07-02 at 4 37 04 PM" src="https://github.com/user-attachments/assets/1c9b48c4-e6d3-4a6f-832e-1332983bf185" />
<img width="647" alt="Screenshot 2025-07-02 at 4 37 36 PM" src="https://github.com/user-attachments/assets/6b592b73-fd0f-4201-94aa-cbd6a358df47" />