### PR TITLE
[ENG-1968] Add isort to linter for PEP8 alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,6 @@ numpy = [
     { version = ">=1.21.0,<2.1.0", python = "<3.10" },
     { version = ">=2.1.0,<3.0", python = ">=3.10" },
 ]
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/src/sqlalchemy_oso_cloud/__init__.py
+++ b/src/sqlalchemy_oso_cloud/__init__.py
@@ -15,10 +15,10 @@ The main features are:
 See the [README](https://github.com/osohq/sqlalchemy-oso-cloud) for more information.
 """
 from . import orm
-from .session import Session
+from .auth import _apply_authorization_options, authorized
+from .oso import get_oso, init
 from .query import Query
-from .oso import init, get_oso
 from .select_impl import Select, select
-from .auth import authorized, _apply_authorization_options
+from .session import Session
 
 __all__ = ["orm", "Session", "Query", "init", "get_oso", "Select", "select", "authorized", "_apply_authorization_options"]

--- a/src/sqlalchemy_oso_cloud/auth.py
+++ b/src/sqlalchemy_oso_cloud/auth.py
@@ -1,7 +1,9 @@
-from sqlalchemy import literal_column, ColumnClause
-from sqlalchemy.orm import with_loader_criteria, LoaderCriteriaOption
+from typing import TYPE_CHECKING, Callable, List, Optional, Set, Type, Union
+
 from oso_cloud import Value
-from typing import List, Set, Type, Callable, Union, Optional, TYPE_CHECKING
+from sqlalchemy import ColumnClause, literal_column
+from sqlalchemy.orm import LoaderCriteriaOption, with_loader_criteria
+
 from .orm import Resource
 from .oso import get_oso
 

--- a/src/sqlalchemy_oso_cloud/orm.py
+++ b/src/sqlalchemy_oso_cloud/orm.py
@@ -3,10 +3,11 @@ Utilities for [declaratively mapping](https://docs.sqlalchemy.org/en/20/orm/mapp
 [authorization data](https://www.osohq.com/docs/authorization-data) in your ORM models.
 """
 
-from typing import Callable, Optional, Protocol, Any
-from typing_extensions import ParamSpec, TypeVar, Concatenate
+from typing import Any, Callable, Optional, Protocol
 
 from sqlalchemy.orm import MappedColumn, Relationship, mapped_column, relationship
+from typing_extensions import Concatenate, ParamSpec, TypeVar
+
 
 class Resource:
   """

--- a/src/sqlalchemy_oso_cloud/oso.py
+++ b/src/sqlalchemy_oso_cloud/oso.py
@@ -1,15 +1,21 @@
 import os
-import yaml
+from tempfile import NamedTemporaryFile
+from typing import Optional, TypedDict, Union
 
-from typing import TypedDict, Optional, Union
+import yaml
 from oso_cloud import Oso
 from sqlalchemy import select
-from sqlalchemy.orm import Mapper, RelationshipProperty, registry, ColumnProperty
+from sqlalchemy.orm import ColumnProperty, Mapper, RelationshipProperty, registry
 from sqlalchemy.sql.elements import NamedColumn
 from sqlalchemy.sql.sqltypes import Boolean, Integer, String, TypeEngine
-from tempfile import NamedTemporaryFile
 
-from .orm import _ATTRIBUTE_INFO_KEY, Resource, _RELATION_INFO_KEY, _REMOTE_RELATION_INFO_KEY
+from .orm import (
+  _ATTRIBUTE_INFO_KEY,
+  _RELATION_INFO_KEY,
+  _REMOTE_RELATION_INFO_KEY,
+  Resource,
+)
+
 
 class FactConfig(TypedDict):
   query: str

--- a/src/sqlalchemy_oso_cloud/query.py
+++ b/src/sqlalchemy_oso_cloud/query.py
@@ -1,6 +1,7 @@
+from typing import Optional, Type, TypeVar
+
 import sqlalchemy.orm
 from oso_cloud import Value
-from typing import Type, TypeVar, Optional
 
 from .auth import _apply_authorization_options
 from .oso import get_oso

--- a/src/sqlalchemy_oso_cloud/select_impl.py
+++ b/src/sqlalchemy_oso_cloud/select_impl.py
@@ -1,6 +1,8 @@
+from typing import TypeVar
+
 import sqlalchemy.sql
 from oso_cloud import Value
-from typing import  TypeVar
+
 from .auth import _apply_authorization_options
 
 Self = TypeVar("Self", bound="Select")

--- a/src/sqlalchemy_oso_cloud/session.py
+++ b/src/sqlalchemy_oso_cloud/session.py
@@ -1,8 +1,10 @@
+from typing import Any, Tuple, Type, TypeVar, Union, overload
+
 import sqlalchemy.orm
-from .query import Query
 from sqlalchemy.engine import Row
 from sqlalchemy.orm.attributes import InstrumentedAttribute
-from typing import Type, TypeVar, overload, Any, Tuple, Union
+
+from .query import Query
 
 T = TypeVar("T")
 T1 = TypeVar("T1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,20 @@
 import socket
-from testcontainers.core.container import DockerContainer  # type: ignore
-from testcontainers.postgres import PostgresContainer  # type: ignore
-from testcontainers.core.waiting_utils import wait_for, wait_container_is_ready  # type: ignore
+
+import pytest
+from oso_cloud import Oso, Value
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.exc import OperationalError
-import pytest
 from sqlalchemy.orm import Session
-from oso_cloud import Oso, Value
+from testcontainers.core.container import DockerContainer  # type: ignore
+from testcontainers.core.waiting_utils import (  # type: ignore
+  wait_container_is_ready,
+  wait_for,
+)
+from testcontainers.postgres import PostgresContainer  # type: ignore
 
 import sqlalchemy_oso_cloud
 
-from .models import Base, Organization, Document
+from .models import Base, Document, Organization
 
 
 @pytest.fixture(scope="session")

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,9 @@
-from pgvector.sqlalchemy import Vector # type: ignore
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from pgvector.sqlalchemy import Vector  # type: ignore
 from sqlalchemy import ForeignKey
-from sqlalchemy_oso_cloud.orm import Resource, relation, attribute, remote_relation
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from sqlalchemy_oso_cloud.orm import Resource, attribute, relation, remote_relation
+
 
 class Base(DeclarativeBase):
   pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,14 @@
-from oso_cloud import Oso, Value
-from sqlalchemy import text, func, select as sqla_select
-from sqlalchemy.orm import Session, joinedload
-from .models import Document, Base, Organization
 import yaml
-
+from oso_cloud import Oso, Value
+from sqlalchemy import func, text
+from sqlalchemy import select as sqla_select
+from sqlalchemy.orm import Session, joinedload
 
 import sqlalchemy_oso_cloud
-from sqlalchemy_oso_cloud import select, authorized
+from sqlalchemy_oso_cloud import authorized, select
+
+from .models import Base, Document, Organization
+
 
 # This is the part our goal is to make nicer
 def test_manual(oso: Oso, session: Session, alice: Value, bob: Value):

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -4,8 +4,12 @@ Test compatibility with pgvector-sqlalchemy
 import numpy as np
 import pytest
 from oso_cloud import Value
-from sqlalchemy import select as sqla_select, text
-from sqlalchemy_oso_cloud import select, authorized, Session as OsoSession
+from sqlalchemy import select as sqla_select
+from sqlalchemy import text
+
+from sqlalchemy_oso_cloud import Session as OsoSession
+from sqlalchemy_oso_cloud import authorized, select
+
 from .models import Document, Organization
 
 if not hasattr(Document, 'embedding'):


### PR DESCRIPTION
Adds [`isort`](https://pycqa.github.io/isort/) onto the default ruff linter with [`extend-select`](https://docs.astral.sh/ruff/settings/#lint_extend-select). This puts our import statements in alignment with [PEP8](https://peps.python.org/pep-0008/#imports). I then ran `poetry run ruff check --fix` to sort the project's import statements.

This is mostly a stylistic change, but I figured this is worth it for a public facing open-source project.

